### PR TITLE
Migrating from discordapp to discord domain

### DIFF
--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -12,7 +12,7 @@ const ROUTES = {
     USER_SETTINGS: "/settings",
     LOADING: "/loading",
     STATS: "/stats",
-    ADD_GEARBOT: "https://discordapp.com/oauth2/authorize?client_id=365497403928870914&scope=bot&permissions=1476783350"
+    ADD_GEARBOT: "https://discord.com/oauth2/authorize?client_id=365497403928870914&scope=bot&permissions=1476783350"
 };
 
 export default ROUTES


### PR DESCRIPTION
**What does this PR add/fix/improve/...**
Discord has begun to migrate their primary Domain from discordapp.com to just discord.com

This PR is intended to update one of the references. The Bot Invite link can be changed now, but the CDN cannot yet, so this PR initially just does the Bot Invite link.

**Migration**
If any migration is required for already setup instances please provide instructions/requirements here

Unlikely to be required, the existing reference is/was unique to the public GearBot instance. The only form of migration for other instances would be to update their invite links.

**Dependencies**
If this requires any other PRs to be merged and deployed in other GearBot reprositories please link them here

Not at this time. While other references will need to be changed, this PR is unlikely to have any impact. The other repositories can be handled independently from this PR.